### PR TITLE
Fixed arrows so that they disappear if the page is last/first or both

### DIFF
--- a/source/core/src/main/resources/static/tools-list/tools-list.html
+++ b/source/core/src/main/resources/static/tools-list/tools-list.html
@@ -87,14 +87,14 @@
 
             <nav aria-label="Page navigation">
                 <ul class="pagination">
-                    <li ng-class="toolsPage.firstPage ? 'page-item disabled' : 'page-item'">
+                    <li ng-show="!toolsPage.firstPage">
                         <button class="page-link" ng-click="loadTools(toolsPage.number)"><<</button>
                     </li>
-                    <li ng-class="toolsPage.number == pageIndex - 1 ? 'page-item active' : 'page-item'"
+                    <li ng-show="toolsPage.totalElements > 0"
                         ng-repeat="pageIndex in paginationArray">
                         <button class="page-link" ng-click="loadTools(pageIndex)">{{pageIndex}}</button>
                     </li>
-                    <li ng-class="toolsPage.last ? 'page-item disabled' : 'page-item'">
+                    <li ng-show="!toolsPage.lastPage">
                         <button class="page-link" ng-click="loadTools(toolsPage.number + 2)">>></button>
                     </li>
                 </ul>


### PR DESCRIPTION
Поправил стрелки, чтобы левая исчезала, если текущая страница первая, а правая - последняя. Также сделал, чтобы номера страниц (даже 1) исчезали, если элементов нет.