### PR TITLE
Добавлена возможность выбрать кол-во элементов на странице

### DIFF
--- a/source/core/src/main/resources/static/tools-list/tools-list.html
+++ b/source/core/src/main/resources/static/tools-list/tools-list.html
@@ -45,16 +45,34 @@
             </div>
         </form>
     </div>
+
     <br/>
+    <br/>
+    <div class="dropdown">
+        <span style="color: darkcyan">Показывать</span>
+        <button class="btn btn-light dropdown-toggle" type="button" id="dropdownMenu1" data-bs-toggle="dropdown" aria-expanded="false">
+            {{pageSize}}</button>
+        <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+            <li><button class="dropdown-item" type="button" ng-click="loadTen()">10</button></li>
+            <li><button class="dropdown-item" type="button" ng-click="loadTwentyFive()">25</button></li>
+            <li><button class="dropdown-item" type="button" ng-click="loadFifty()">50</button></li>
+        </ul>
+        <span style="color: darkcyan">Элементов на странице</span>
+    </div>
+    <br/>
+    <br/>
+
     <div class="dropdown">
         <button class="btn btn-warning dropdown-toggle" type="button" id="dropdownMenu2" data-bs-toggle="dropdown" aria-expanded="false">
             Сортировка
         </button>
+        <span style="color: darkcyan">{{sortTypeInfoForUser}}</span>
         <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
-            <li><button class="dropdown-item" type="button" ng-click="loadTools(0, 'fee,asc')">По возрастанию цены аренды</button></li>
-            <li><button class="dropdown-item" type="button" ng-click="loadTools(0, 'fee,desc')">По убыванию цены аренды</button></li>
-            <li><button class="dropdown-item" type="button" ng-click="loadTools(0, 'price,asc')">По возрастанию стоимости залога</button></li>
-            <li><button class="dropdown-item" type="button" ng-click="loadTools(0, 'price,desc')">По убыванию стоимости залога</button></li>
+            <li><button class="dropdown-item" type="button" ng-click="withoutSorting()">Без сортировки</button></li>
+            <li><button class="dropdown-item" type="button" ng-click="sortFeeAsc()">По возрастанию цены аренды</button></li>
+            <li><button class="dropdown-item" type="button" ng-click="sortFeeDesc()">По убыванию цены аренды</button></li>
+            <li><button class="dropdown-item" type="button" ng-click="sortPriceAsc()">По возрастанию стоимости залога</button></li>
+            <li><button class="dropdown-item" type="button" ng-click="sortPriceDesc()">По убыванию стоимости залога</button></li>
         </ul>
     </div>
     <div class="mt-4"></div>

--- a/source/core/src/main/resources/static/tools-list/tools-list.js
+++ b/source/core/src/main/resources/static/tools-list/tools-list.js
@@ -2,15 +2,19 @@
 angular.module('tools').controller('toolsListController', function ($scope, $http, $location,$routeParams, $localStorage) {
     const contextPath = 'http://localhost:8890/let-me-rent/';
     let currentPageIndex = 1;
+    $scope.pageSize = 10;
+    $scope.sortTypeInfoForUser = "Без сортировки";
+    $scope.sortTypeForServer = null;
 
-    $scope.loadTools = function (pageIndex = 0, sorting = null) {
+    $scope.loadTools = function (pageIndex = 0) {
         currentPageIndex = pageIndex;
         $http({
             url: contextPath + "api/v1/instruments",
             method: 'GET',
             params: {
                 page: pageIndex,
-                sort: sorting,
+                size: $scope.pageSize,
+                sort: $scope.sortTypeForServer,
                 title: $scope.filter ? $scope.filter.title : null,
                 categoryName: $scope.filter ? $scope.filter.categoryName : null,
                 ownerUserName: $scope.filter ? $scope.filter.ownerUserName : null,
@@ -24,6 +28,50 @@ angular.module('tools').controller('toolsListController', function ($scope, $htt
         });
     };
 
+    $scope.loadTen = function () {
+        $scope.pageSize=10;
+        $scope.loadTools();
+    }
+
+    $scope.loadTwentyFive = function () {
+        $scope.pageSize=25;
+        $scope.loadTools();
+    }
+
+    $scope.loadFifty = function () {
+        $scope.pageSize=50;
+        $scope.loadTools();
+    }
+
+    $scope.sortFeeAsc = function () {
+        $scope.sortTypeForServer="'fee,asc'";
+        $scope.sortTypeInfoForUser="По возрастанию цены аренды";
+        $scope.loadTools();
+    }
+
+    $scope.sortFeeDesc = function () {
+        $scope.sortTypeForServer="'fee,desc'";
+        $scope.sortTypeInfoForUser="По убыванию цены аренды";
+        $scope.loadTools();
+    }
+
+    $scope.sortPriceAsc = function () {
+        $scope.sortTypeForServer="'price,asc'";
+        $scope.sortTypeInfoForUser="По возрастанию стоимости залога";
+        $scope.loadTools();
+    }
+
+    $scope.sortPriceDesc = function () {
+        $scope.sortTypeForServer="'price,desc'";
+        $scope.sortTypeInfoForUser="По убыванию стоимости залога";
+        $scope.loadTools();
+    }
+
+    $scope.withoutSorting = function () {
+        $scope.sortTypeForServer=null;
+        $scope.sortTypeInfoForUser="Без сортировки";
+        $scope.loadTools();
+    }
 
     $scope.generatePagesIndexes = function (startPage, endPage) {
         let arr = [];
@@ -54,15 +102,6 @@ angular.module('tools').controller('toolsListController', function ($scope, $htt
 
     $scope.navToToolInfoPage = function (toolId) {
         $location.path('/tool-info/' + toolId);
-    }
-
-
-    $scope.tryToRent = function (toolId) {
-        //    ТУТ ЕСЛИ НЕ АВТОРИЗОВАН, ТО АЛЕРТ, ЧТО НАДО АВТОРИЗОВАТЬСЯ СНАЧАЛА, И ПЕРЕБРОСКА НА
-        // СТРАНИЦУ АВТОРИЗАЦИИ
-        // $location.path('/authorisation');
-        // А после авторизации/если авторизован, то уже формируем запрос на аренду на отдельной странице:
-        $location.path('/rent-request-page/' + toolId);
     }
 
     $scope.putIntoCart = function (toolId) {


### PR DESCRIPTION
От ветки, где сделана сортировка, я сделала отдельную ветку, в которой, помимо сортировки, еще есть выбор варианта количества элементов на странице.

Поменяла порядок передачи параметров по размеру и сортировке в запрос - теперь они сохраняются в переменных. Дело в том, что если пользователь сначала выбрал сортировку, а потом выбрал кол-во элементов на странице, то при загрузке списка должно бы учтено и то, какая сортировка применена и то, сколько элементов хочет видеть пользователь.
У меня до 4-го числа нет доступа к компу, где я могу запустить наше приложение и посмотреть, как это по факту срабатывает. Буду признательная, если Татьяна подключится к этой задаче и посмотрит работоспособность и, может, на свой вкус что-то подправит в том числе визуально.
Мне кажется, что решение с сохранением сведений о сортировке и количестве элементов в переменных на фронте где-то еще может пригодиться. Хотя могу ошибаться.
Если это катастрофически заморочно у меня получилось, можно оптимизировать или остаться на варианте, где только сортировка (без кол-ва элементов на странице): тогда ветка LMR-46 остается в том виде, что уже есть.